### PR TITLE
Adds tzdata package to passenger container

### DIFF
--- a/passenger/Dockerfile
+++ b/passenger/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
       ruby-rmagick \
       ruby2.3 \
       ruby2.3-dev \
+      tzdata \
       zlib1g-dev && \
     apt-get clean
 


### PR DESCRIPTION
This fixes applications like redmine which require a tzdata source.