### PR TITLE
SFTP user writable locked directory.

### DIFF
--- a/sftp/dev/Dockerfile
+++ b/sftp/dev/Dockerfile
@@ -23,9 +23,11 @@ RUN useradd $FTP_USER && \
 COPY sshd_config /etc/ssh/sshd_config
 
 # Data.
-RUN mkdir -p /data && \
+RUN mkdir -p /data/$FTP_USER && \
     chown root:root /data && \
-    chmod 755 /data
+    chmod 755 /data && \
+    chown ${FTP_USER}:${FTP_USER} /data/${FTP_USER} && \
+    chmod 755 /data/${FTP_USER}
 
 # Custom on build configuration.
 ONBUILD ADD authorized_keys /home/${FTP_USER}/.ssh/authorized_keys


### PR DESCRIPTION
#### What does this PR do?
Add a directory to the /data directory that is writable by the chrooted sftp user

#### How should this be manually tested?
This can be tested with the docs containers README instructions.

#### Any background context you want to provide?
Developers require a "mock" sftp server for local development.

#### What are the relevant tickets?
RM#42520

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A

##### Does any external documentation require updating?
Have provided README inside container directory.

##### Does this changeset require specific versions of supporting software?
N/A
