### PR TITLE
Xdebug script for dynamically setting the xdebug.so file

### DIFF
--- a/php/5.6/dev/Dockerfile
+++ b/php/5.6/dev/Dockerfile
@@ -37,6 +37,8 @@ RUN echo '[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
 RUN pecl install -o -f xdebug && \
     rm -rf /tmp/pear
 ADD xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+ADD scripts/xdebug-set.sh /usr/local/bin/xdebug-set.sh
+RUN /usr/local/bin/xdebug-set.sh /usr/local/etc/php/conf.d/xdebug.ini
 
 # Skipper CLI toolkit.
 RUN wget http://bins.skpr.io/linux-amd64-latest.tar.gz && \

--- a/php/5.6/dev/scripts/xdebug-set.sh
+++ b/php/5.6/dev/scripts/xdebug-set.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1 | sed 's/\//\\\//g')
 
-sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1
+sed -i -e "s/XDEBUG_SO/'$XDEBUG_SO'/g" $1

--- a/php/5.6/dev/scripts/xdebug-set.sh
+++ b/php/5.6/dev/scripts/xdebug-set.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+
+sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1

--- a/php/5.6/dev/xdebug.ini
+++ b/php/5.6/dev/xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so
+zend_extension=XDEBUG_SO
 xdebug.max_nesting_level=256 ; Fixes debugging for D8.
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp

--- a/php/7.0/dev/Dockerfile
+++ b/php/7.0/dev/Dockerfile
@@ -37,6 +37,8 @@ RUN echo '[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
 RUN pecl install -o -f xdebug && \
     rm -rf /tmp/pear
 ADD xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+ADD scripts/xdebug-set.sh /usr/local/bin/xdebug-set.sh
+RUN /usr/local/bin/xdebug-set.sh /usr/local/etc/php/conf.d/xdebug.ini
 
 # Skipper CLI toolkit.
 RUN wget http://bins.skpr.io/linux-amd64-latest.tar.gz && \

--- a/php/7.0/dev/scripts/xdebug-set.sh
+++ b/php/7.0/dev/scripts/xdebug-set.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1 | sed 's/\//\\\//g')
 
-sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1
+sed -i -e "s/XDEBUG_SO/'$XDEBUG_SO'/g" $1

--- a/php/7.0/dev/scripts/xdebug-set.sh
+++ b/php/7.0/dev/scripts/xdebug-set.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+
+sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1

--- a/php/7.0/dev/xdebug.ini
+++ b/php/7.0/dev/xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so
+zend_extension=XDEBUG_SO
 xdebug.max_nesting_level=256 ; Fixes debugging for D8.
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp

--- a/php/7.1/dev/Dockerfile
+++ b/php/7.1/dev/Dockerfile
@@ -37,6 +37,8 @@ RUN echo '[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
 RUN pecl install -o -f xdebug && \
     rm -rf /tmp/pear
 ADD xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+ADD scripts/xdebug-set.sh /usr/local/bin/xdebug-set.sh
+RUN /usr/local/bin/xdebug-set.sh /usr/local/etc/php/conf.d/xdebug.ini
 
 # Skipper CLI toolkit.
 RUN wget http://bins.skpr.io/linux-amd64-latest.tar.gz && \

--- a/php/7.1/dev/scripts/xdebug-set.sh
+++ b/php/7.1/dev/scripts/xdebug-set.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1 | sed 's/\//\\\//g')
 
-sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1
+sed -i -e "s/XDEBUG_SO/'$XDEBUG_SO'/g" $1

--- a/php/7.1/dev/scripts/xdebug-set.sh
+++ b/php/7.1/dev/scripts/xdebug-set.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+
+sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1

--- a/php/7.1/dev/xdebug.ini
+++ b/php/7.1/dev/xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so
+zend_extension=XDEBUG_SO
 xdebug.max_nesting_level=256 ; Fixes debugging for D8.
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp

--- a/php/7.x/dev/Dockerfile
+++ b/php/7.x/dev/Dockerfile
@@ -37,6 +37,8 @@ RUN echo '[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
 RUN pecl install -o -f xdebug && \
     rm -rf /tmp/pear
 ADD xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+ADD scripts/xdebug-set.sh /usr/local/bin/xdebug-set.sh
+RUN /usr/local/bin/xdebug-set.sh /usr/local/etc/php/conf.d/xdebug.ini
 
 # Skipper CLI toolkit.
 RUN wget http://bins.skpr.io/linux-amd64-latest.tar.gz && \

--- a/php/7.x/dev/scripts/xdebug-set.sh
+++ b/php/7.x/dev/scripts/xdebug-set.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1 | sed 's/\//\\\//g')
 
-sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1
+sed -i -e "s/XDEBUG_SO/'$XDEBUG_SO'/g" $1

--- a/php/7.x/dev/scripts/xdebug-set.sh
+++ b/php/7.x/dev/scripts/xdebug-set.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+XDEBUG_SO=$(ls /usr/local/lib/php/extensions/*/xdebug.so | head -n1)
+
+sed -i -e "s/XDEBUG_SO/${XDEBUG_SO}/g" $1

--- a/php/7.x/dev/xdebug.ini
+++ b/php/7.x/dev/xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so
+zend_extension=XDEBUG_SO
 xdebug.max_nesting_level=256 ; Fixes debugging for D8.
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp


### PR DESCRIPTION
#### What does this PR do?

Fixes hard coded xdebug.so references by doing a "find and replace" strategy.

#### How should this be manually tested?

Build the files

Build the containers with (this PR will do that as well)

`make php`

#### Any background context you want to provide?

Lots of local devs keep getting missing xdebug.so files.

#### What are the relevant tickets?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions:

##### Does any external documentation require updating?

Nope

##### Does this changeset require specific versions of supporting software?
(i.e. Go / Terraform / Docker)

Nope