### PR TITLE
Added new container image for building golang projects.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,11 @@ jobs:
     environment:
       - PLATFORM: oauth2
 
+  golang:
+    <<: *build_image
+    environment:
+      - PLATFORM: golang
+
 workflows:
   version: 2
   build:
@@ -61,3 +66,4 @@ workflows:
       - solr
       - apache2
       - oauth2
+      - golang

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ sftp:
 	cd sftp/dev && $(DOCKER) -t previousnext/sftp:latest .
 
 # Build & push go build container.
-golang:
+golang-push:
 	cd golang && make build && make push
 
-.PHONY: php php-push php-5.6 php-5.6-push php-7.0 php-7.0-push php-7.1 php-7.1-push php-7.x php-7.x-push solr-4.x solr-5.x apache2 oauth2 mkdocs passenger clamav mkdocs varnish-4.x sftp golang
+.PHONY: php php-push php-5.6 php-5.6-push php-7.0 php-7.0-push php-7.1 php-7.1-push php-7.x php-7.x-push solr-4.x solr-5.x apache2 oauth2 mkdocs passenger clamav mkdocs varnish-4.x sftp golang-push

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 DOCKER=docker build -f Dockerfile
 
 # Builds all containers.
-all: php solr apache2 oauth2
+all: php solr apache2 oauth2 golang
 
 # Builds all PHP prod and dev containers.
 php: php-5.6 php-7.0 php-7.1 php-7.x
@@ -104,5 +104,8 @@ oauth2-push:
 sftp:
 	cd sftp/dev && $(DOCKER) -t previousnext/sftp:latest .
 
-.PHONY: php php-push php-5.6 php-5.6-push php-7.0 php-7.0-push php-7.1 php-7.1-push php-7.x php-7.x-push solr-4.x solr-5.x apache2 oauth2 mkdocs passenger clamav mkdocs varnish-4.x sftp
+# Build & push go build container.
+golang:
+	cd golang && make build && make push
 
+.PHONY: php php-push php-5.6 php-5.6-push php-7.0 php-7.0-push php-7.1 php-7.1-push php-7.x php-7.x-push solr-4.x solr-5.x apache2 oauth2 mkdocs passenger clamav mkdocs varnish-4.x sftp golang

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,6 @@
+FROM circleci/golang:1.8
+
+RUN go get github.com/tcnksm/ghr && \
+    go get github.com/mitchellh/gox && \
+    go get github.com/jstemmer/go-junit-report && \
+    go get github.com/golang/lint/golint

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -1,0 +1,13 @@
+#!/usr/bin/make -f
+
+IMAGE=previousnext/golang
+VERSION=1.8
+
+default: build push
+
+build:
+	docker build -t $(IMAGE):latest -t $(IMAGE):$(VERSION) .
+
+push:
+	docker push $(IMAGE):latest
+	docker push $(IMAGE):$(VERSION)

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,16 @@
+# Container
+
+## Go Builder
+
+Container image for building go projects on CircleCI. Based on `circleci/golang`
+and adds utilities for optimising `pnx-project-go` projects.
+
+## Update Image
+
+```
+# Build image.
+make build
+
+# Push image.
+make push
+```


### PR DESCRIPTION
Contains dependencies baked into pnx-project-go.

#### What does this PR do?

Adds a new container image for building go projects. It extends `circleci/golang` and installs the following utilities.

- `github.com/tcnksm/ghr` - tool for pushing release artifacts to github.
- `github.com/mitchellh/gox` - cross-platform build tool.
- `github.com/jstemmer/go-junit-report` - unit test reporting tool.
- `github.com/golang/lint/golint` - lint tool.

#### How should this be manually tested?

Build and push the image.

```
make golang
```

#### Any background context you want to provide?

Motivation for this PR:

- Standardise on build helper utilities
- Speed up builds by skipping dependency installation.

#### What are the relevant tickets?

N/A

#### Screenshots (if appropriate)


#### Questions:


##### Does any external documentation require updating?

pnx-project-go needs updating to use this image after being merged.
