### PR TITLE
Added Go 1.9 build container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ sftp:
 
 # Build & push go build container.
 golang-push:
-	cd golang && make build && make push
+	cd golang && make GO_VERSION=1.8
+	cd golang && make GO_VERSION=1.9
 
 # Build & push go build container.
 pnx-packager-push:

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,5 @@
-FROM circleci/golang:1.8
+ARG GO_VERSION=1.8
+FROM circleci/golang:${GO_VERSION}
 
 RUN go get github.com/tcnksm/ghr && \
     go get github.com/mitchellh/gox && \

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -1,13 +1,13 @@
 #!/usr/bin/make -f
 
 IMAGE=previousnext/golang
-VERSION=1.8
+GO_VERSION=1.8
 
 default: build push
 
 build:
-	docker build -t $(IMAGE):latest -t $(IMAGE):$(VERSION) .
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t $(IMAGE):$(GO_VERSION) .
 
 push:
 	docker push $(IMAGE):latest
-	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE):$(GO_VERSION)


### PR DESCRIPTION
#### What does this PR do?

* Adds Go 1.9 build container.

#### How should this be manually tested?

`docker run --rm previousnext/golang:1.9 go version`

#### Any background context you want to provide?

Go 1.9 adds a feature where `go test -cover ./...` doesn't traverse into `vendor`. Required if we just want to test our own code.

