### PR TITLE
Proxy

### DIFF
--- a/php/5.6-apache-jessie/base/Dockerfile
+++ b/php/5.6-apache-jessie/base/Dockerfile
@@ -73,10 +73,6 @@ RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-
 RUN curl -L https://github.com/previousnext/skipper-backup/releases/download/0.0.1/skipper-backup-linux-amd64 -o /usr/local/bin/backup && \
       chmod +rx /usr/local/bin/backup
 
-# Script that kicks it all off
-ADD start.sh /usr/local/bin/start
-RUN chmod a+x /usr/local/bin/start
-
 # New Relic.
 ADD scripts/configure-new-relic.sh /usr/local/bin/configure-new-relic
 RUN chmod a+x /usr/local/bin/configure-new-relic
@@ -101,10 +97,13 @@ RUN apt-get -y remove --purge \
       cpp \
       cpp-4.9
 
-# Healthz checks. 
+# Healthz checks.
 COPY healthz /var/www/healthz
 
 # Github.
 RUN mkdir -p /root/.ssh && ssh-keyscan github.com >> /root/.ssh/known_hosts
 
-CMD ["/usr/local/bin/start"]
+ADD start.sh /usr/local/bin/start
+RUN chmod a+x /usr/local/bin/start
+
+CMD ["start"]

--- a/php/5.6-apache-jessie/dev/Dockerfile
+++ b/php/5.6-apache-jessie/dev/Dockerfile
@@ -35,6 +35,13 @@ RUN apt-get update && \
 RUN echo '[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
               . /usr/share/bash-completion/bash_completion' >> ~/.bashrc
 
+# Add proxy rules which will allow us to acces Mailhog and Solr.
+#   /mailhog -> https://127.0.0.1:8025
+#   /solr    -> https://127.0.0.1:8983
+# This is handy for consistency between our local and m8s environments.
+ADD proxy.conf /etc/apache2/conf-enabled/proxy.conf
+RUN a2enmod proxy proxy_http proxy_wstunnel
+
 # https://github.com/docker-library/php/issues/77#issuecomment-88936146
 RUN pecl install -o -f xdebug-2.5.5 && \
     rm -rf /tmp/pear

--- a/php/5.6-apache-jessie/dev/Dockerfile
+++ b/php/5.6-apache-jessie/dev/Dockerfile
@@ -86,3 +86,9 @@ RUN curl -L https://github.com/previousnext/notify/releases/download/2.1.0/notif
 # MicroCron - https://github.com/previousnext/microcron
 RUN curl -L https://github.com/previousnext/microcron/releases/download/v0.0.1/microcron_linux_amd64 -o /usr/local/bin/microcron && \
       chmod +rx /usr/local/bin/microcron
+
+ADD scripts/basic-auth.sh /usr/local/bin/basic-auth
+RUN chmod a+x /usr/local/bin/basic-auth
+
+# Execute the basic-auth prior to starting the container.
+CMD ["/bin/sh", "-c", "basic-auth && start"]

--- a/php/5.6-apache-jessie/dev/proxy.conf
+++ b/php/5.6-apache-jessie/dev/proxy.conf
@@ -1,0 +1,18 @@
+<IfModule mod_proxy.c>
+
+<Location /mailhog>
+  ProxyPass "http://127.0.0.1:8025/mailhog"
+  ProxyPassReverse "http://127.0.0.1:8025/mailhog"
+</Location>
+
+<Location /mailhog/api/v2/websocket>
+  ProxyPass "ws://127.0.0.1:8025/mailhog/api/v2/websocket"
+  ProxyPassReverse "ws://127.0.0.1:8025/mailhog/api/v2/websocket"
+</Location>
+
+<Location /solr>
+  ProxyPass "http://127.0.0.1:8983/solr"
+  ProxyPassReverse "http://127.0.0.1:8983/solr"
+</Location>
+
+</IfModule>

--- a/php/5.6-apache-jessie/dev/scripts/basic-auth.sh
+++ b/php/5.6-apache-jessie/dev/scripts/basic-auth.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Name:    basic-auth.sh
+# Author:  Nick Schuch
+# Comment: Script for configuring Basic Auth
+
+if [ "$BASIC_AUTH_USER" == "" ]; then
+  exit 0
+fi
+
+if [ "$BASIC_AUTH_PASS" == "" ]; then
+  exit 0
+fi
+
+mkdir -p /etc/htpasswd
+htpasswd -b -c /etc/htpasswd/.htpasswd $BASIC_AUTH_USER $BASIC_AUTH_PASS
+cat >/etc/apache2/conf-enabled/basic-auth.conf <<EOL
+<Location "/">
+  AuthType Basic
+  AuthName "Authentication Required"
+  AuthUserFile /etc/htpasswd/.htpasswd
+  Require valid-user
+
+  Order allow,deny
+  Allow from all
+</Location>
+EOL

--- a/php/7.x-apache-jessie/base/Dockerfile
+++ b/php/7.x-apache-jessie/base/Dockerfile
@@ -73,10 +73,6 @@ RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-
 RUN curl -L https://github.com/previousnext/skipper-backup/releases/download/0.0.1/skipper-backup-linux-amd64 -o /usr/local/bin/backup && \
       chmod +rx /usr/local/bin/backup
 
-# Script that kicks it all off
-ADD start.sh /usr/local/bin/start
-RUN chmod a+x /usr/local/bin/start
-
 # New Relic.
 ADD scripts/configure-new-relic.sh /usr/local/bin/configure-new-relic
 RUN chmod a+x /usr/local/bin/configure-new-relic
@@ -106,5 +102,8 @@ COPY healthz /var/www/healthz
 
 # Github.
 RUN mkdir -p /root/.ssh && ssh-keyscan github.com >> /root/.ssh/known_hosts
+
+ADD start.sh /usr/local/bin/start
+RUN chmod a+x /usr/local/bin/start
 
 CMD ["/usr/local/bin/start"]

--- a/php/7.x-apache-jessie/dev/Dockerfile
+++ b/php/7.x-apache-jessie/dev/Dockerfile
@@ -88,3 +88,9 @@ RUN curl -L https://github.com/previousnext/notify/releases/download/2.1.0/notif
 # MicroCron - https://github.com/previousnext/microcron
 RUN curl -L https://github.com/previousnext/microcron/releases/download/v0.0.1/microcron_linux_amd64 -o /usr/local/bin/microcron && \
       chmod +rx /usr/local/bin/microcron
+
+ADD scripts/basic-auth.sh /usr/local/bin/basic-auth
+RUN chmod a+x /usr/local/bin/basic-auth
+
+# Execute the basic-auth prior to starting the container.
+CMD ["/bin/sh", "-c", "basic-auth && start"]

--- a/php/7.x-apache-jessie/dev/Dockerfile
+++ b/php/7.x-apache-jessie/dev/Dockerfile
@@ -36,6 +36,13 @@ RUN apt-get update && \
 RUN echo '[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
               . /usr/share/bash-completion/bash_completion' >> ~/.bashrc
 
+# Add proxy rules which will allow us to acces Mailhog and Solr.
+#   /mailhog -> https://127.0.0.1:8025
+#   /solr    -> https://127.0.0.1:8983
+# This is handy for consistency between our local and m8s environments.
+ADD proxy.conf /etc/apache2/conf-enabled/proxy.conf
+RUN a2enmod proxy proxy_http proxy_wstunnel
+
 # https://github.com/docker-library/php/issues/77#issuecomment-88936146
 RUN pecl install -o -f xdebug && \
     rm -rf /tmp/pear

--- a/php/7.x-apache-jessie/dev/proxy.conf
+++ b/php/7.x-apache-jessie/dev/proxy.conf
@@ -1,0 +1,18 @@
+<IfModule mod_proxy.c>
+
+<Location /mailhog>
+  ProxyPass "http://127.0.0.1:8025/mailhog"
+  ProxyPassReverse "http://127.0.0.1:8025/mailhog"
+</Location>
+
+<Location /mailhog/api/v2/websocket>
+  ProxyPass "ws://127.0.0.1:8025/mailhog/api/v2/websocket"
+  ProxyPassReverse "ws://127.0.0.1:8025/mailhog/api/v2/websocket"
+</Location>
+
+<Location /solr>
+  ProxyPass "http://127.0.0.1:8983/solr"
+  ProxyPassReverse "http://127.0.0.1:8983/solr"
+</Location>
+
+</IfModule>

--- a/php/7.x-apache-jessie/dev/scripts/basic-auth.sh
+++ b/php/7.x-apache-jessie/dev/scripts/basic-auth.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Name:    basic-auth.sh
+# Author:  Nick Schuch
+# Comment: Script for configuring Basic Auth
+
+if [ "$BASIC_AUTH_USER" == "" ]; then
+  exit 0
+fi
+
+if [ "$BASIC_AUTH_PASS" == "" ]; then
+  exit 0
+fi
+
+mkdir -p /etc/htpasswd
+htpasswd -b -c /etc/htpasswd/.htpasswd $BASIC_AUTH_USER $BASIC_AUTH_PASS
+cat >/etc/apache2/conf-enabled/basic-auth.conf <<EOL
+<Location "/">
+  AuthType Basic
+  AuthName "Authentication Required"
+  AuthUserFile /etc/htpasswd/.htpasswd
+  Require valid-user
+
+  Order allow,deny
+  Allow from all
+</Location>
+EOL

--- a/php/7.x-apache-stretch/base/Dockerfile
+++ b/php/7.x-apache-stretch/base/Dockerfile
@@ -71,10 +71,6 @@ RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-
 RUN curl -L https://github.com/previousnext/skipper-backup/releases/download/0.0.1/skipper-backup-linux-amd64 -o /usr/local/bin/backup && \
       chmod +rx /usr/local/bin/backup
 
-# Script that kicks it all off
-ADD start.sh /usr/local/bin/start
-RUN chmod a+x /usr/local/bin/start
-
 # New Relic.
 ADD scripts/configure-new-relic.sh /usr/local/bin/configure-new-relic
 RUN chmod a+x /usr/local/bin/configure-new-relic
@@ -99,5 +95,8 @@ COPY healthz /var/www/healthz
 
 # Github.
 RUN mkdir -p /root/.ssh && ssh-keyscan github.com >> /root/.ssh/known_hosts
+
+ADD start.sh /usr/local/bin/start
+RUN chmod a+x /usr/local/bin/start
 
 CMD ["/usr/local/bin/start"]

--- a/php/7.x-apache-stretch/dev/Dockerfile
+++ b/php/7.x-apache-stretch/dev/Dockerfile
@@ -33,6 +33,13 @@ RUN apt-get update && \
 RUN echo '[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
               . /usr/share/bash-completion/bash_completion' >> ~/.bashrc
 
+# Add proxy rules which will allow us to acces Mailhog and Solr.
+#   /mailhog -> https://127.0.0.1:8025
+#   /solr    -> https://127.0.0.1:8983
+# This is handy for consistency between our local and m8s environments.
+ADD proxy.conf /etc/apache2/conf-enabled/proxy.conf
+RUN a2enmod proxy proxy_http proxy_wstunnel
+
 # https://github.com/docker-library/php/issues/77#issuecomment-88936146
 RUN pecl install -o -f xdebug && \
     rm -rf /tmp/pear

--- a/php/7.x-apache-stretch/dev/Dockerfile
+++ b/php/7.x-apache-stretch/dev/Dockerfile
@@ -85,3 +85,9 @@ RUN curl -L https://github.com/previousnext/notify/releases/download/2.1.0/notif
 # MicroCron - https://github.com/previousnext/microcron
 RUN curl -L https://github.com/previousnext/microcron/releases/download/v0.0.1/microcron_linux_amd64 -o /usr/local/bin/microcron && \
       chmod +rx /usr/local/bin/microcron
+
+ADD scripts/basic-auth.sh /usr/local/bin/basic-auth
+RUN chmod a+x /usr/local/bin/basic-auth
+
+# Execute the basic-auth prior to starting the container.
+CMD ["/bin/sh", "-c", "basic-auth && start"]

--- a/php/7.x-apache-stretch/dev/proxy.conf
+++ b/php/7.x-apache-stretch/dev/proxy.conf
@@ -1,0 +1,18 @@
+<IfModule mod_proxy.c>
+
+<Location /mailhog>
+  ProxyPass "http://127.0.0.1:8025/mailhog"
+  ProxyPassReverse "http://127.0.0.1:8025/mailhog"
+</Location>
+
+<Location /mailhog/api/v2/websocket>
+  ProxyPass "ws://127.0.0.1:8025/mailhog/api/v2/websocket"
+  ProxyPassReverse "ws://127.0.0.1:8025/mailhog/api/v2/websocket"
+</Location>
+
+<Location /solr>
+  ProxyPass "http://127.0.0.1:8983/solr"
+  ProxyPassReverse "http://127.0.0.1:8983/solr"
+</Location>
+
+</IfModule>

--- a/php/7.x-apache-stretch/dev/scripts/basic-auth.sh
+++ b/php/7.x-apache-stretch/dev/scripts/basic-auth.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Name:    basic-auth.sh
+# Author:  Nick Schuch
+# Comment: Script for configuring Basic Auth
+
+if [ "$BASIC_AUTH_USER" == "" ]; then
+  exit 0
+fi
+
+if [ "$BASIC_AUTH_PASS" == "" ]; then
+  exit 0
+fi
+
+mkdir -p /etc/htpasswd
+htpasswd -b -c /etc/htpasswd/.htpasswd $BASIC_AUTH_USER $BASIC_AUTH_PASS
+cat >/etc/apache2/conf-enabled/basic-auth.conf <<EOL
+<Location "/">
+  AuthType Basic
+  AuthName "Authentication Required"
+  AuthUserFile /etc/htpasswd/.htpasswd
+  Require valid-user
+
+  Order allow,deny
+  Allow from all
+</Location>
+EOL


### PR DESCRIPTION
#### What does this PR do?

* Adds proxy for "/mailhog" and "/solr" for consistency between m8s and local dev.
* Configurable http auth for dev containers

#### How should this be manually tested?

* Go to "/mailhog" and "/solr" while running solr and mailhog containers.
* Set "BASIC_AUTH_USER" and "BASIC_AUTH_PASS" in your docker compose, auth will be set.

#### Any background context you want to provide?

* Allows us to have more generic support for "/mailhog" and "/solr" for m8s.

#### What are the relevant tickets?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions:

##### Does any external documentation require updating?

N/A

##### Does this changeset require specific versions of supporting software?
(i.e. Go / Terraform / Docker)

N/A