### PR TITLE
Unpinned the 5.x solr container from the patch version.

### DIFF
--- a/solr/5.x/Dockerfile
+++ b/solr/5.x/Dockerfile
@@ -1,4 +1,4 @@
-FROM  solr:5.5.4
+FROM  solr:5.5
 LABEL maintainer="admin@previousnext.com.au"
 
 ENV SOLR_HEAP="256m"


### PR DESCRIPTION
Gives us access to a new feature - configuring the port using `SOLR_PORT` environment variable.