### PR TITLE
Add AWS CLI to pnx-packager image.

### DIFF
--- a/pnx-packager/Dockerfile
+++ b/pnx-packager/Dockerfile
@@ -1,10 +1,20 @@
 FROM debian:stable-slim
 
-RUN apt-get update && apt-get install -y git curl make && rm -rf /var/cache/apt/*
+RUN apt-get update && apt-get install -y git curl make virtualenv && rm -rf /var/cache/apt/*
+
+# Docker client.
 RUN curl -Ls -o /tmp/docker-17.09.0-ce.tgz https://download.docker.com/linux/static/stable/x86_64/docker-17.09.0-ce.tgz && \
 	  tar -xz -C /tmp -f /tmp/docker-17.09.0-ce.tgz && \
     mv /tmp/docker/* /usr/local/bin && \
     rm -rf /tmp/docker
+
+# Skipper binaries.
 RUN curl -Ls -o /tmp/skpr-linux-amd64-latest.tar.gz http://bins.skpr.io/linux-amd64-latest.tar.gz && \
     tar -zxf /tmp/skpr-linux-amd64-latest.tar.gz -C /usr/local/bin/ && \
     rm -rf /tmp/*
+
+# Install aws utilities.
+RUN virtualenv --python=python3 /usr/local/share/virtualenv
+RUN echo ". /usr/local/share/virtualenv/bin/activate" >> /root/.bashrc
+RUN . /root/.bashrc && \
+    pip install awscli


### PR DESCRIPTION
#### What does this PR do?

Add AWS CLI to pnx-packager image.


#### Any background context you want to provide?

Allows deployments of static sites to s3, creating cloudfront invalidations etc..
