### PR TITLE
Add ssh client

### DIFF
--- a/php/apache/dev/Dockerfile
+++ b/php/apache/dev/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add -u g++ \
                patch \
                php7-xdebug \
                python \
+               openssh-client \
                wget \
                yarn && \
     rm -rf /var/cache/apk/*

--- a/php/apache/dev/tests/tools.yml
+++ b/php/apache/dev/tests/tools.yml
@@ -10,3 +10,8 @@ commandTests:
     command: "which"
     args: ["patch"]
     expectedOutput: ["/usr/bin/patch"]
+
+  - name: 'command exists: ssh'
+    command: "which"
+    args: ["ssh"]
+    expectedOutput: ["/usr/bin/ssh"]


### PR DESCRIPTION
## Why?

Any CI task, e.g. patchy, which requires authentication for a git repo in the format git@github.com needs ssh.
