### PR TITLE
[#52191] Adds RDS CA certificate.

### DIFF
--- a/php/5.6-apache-jessie/base/Dockerfile
+++ b/php/5.6-apache-jessie/base/Dockerfile
@@ -72,6 +72,9 @@ RUN curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer \
     && chmod +x /usr/local/bin/composer
 
+# Add Amazon RDS TLS public certificate.
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem  /etc/ssl/certs/rds-combined-ca-bundle.pem
+
 # Tuner - https://github.com/previousnext/tuner
 RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-linux-amd64 -o /usr/local/bin/tuner && \
       chmod +rx /usr/local/bin/tuner

--- a/php/7.x-apache-jessie/base/Dockerfile
+++ b/php/7.x-apache-jessie/base/Dockerfile
@@ -76,6 +76,9 @@ RUN curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer \
     && chmod +x /usr/local/bin/composer
 
+# Add Amazon RDS TLS public certificate.
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem  /etc/ssl/certs/rds-combined-ca-bundle.pem
+
 # Tuner - https://github.com/previousnext/tuner
 RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-linux-amd64 -o /usr/local/bin/tuner && \
       chmod +rx /usr/local/bin/tuner

--- a/php/7.x-apache-stretch/base/Dockerfile
+++ b/php/7.x-apache-stretch/base/Dockerfile
@@ -64,6 +64,9 @@ RUN rm -f /etc/apache2/sites-enabled/*
 COPY drushrc.php /etc/drush/drushrc.php
 COPY skpr.php /etc/skpr.php
 
+# Add Amazon RDS TLS public certificate.
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem  /etc/ssl/certs/rds-combined-ca-bundle.pem
+
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer \

--- a/php/apache/Dockerfile
+++ b/php/apache/Dockerfile
@@ -75,6 +75,9 @@ COPY newrelic.ini /etc/php7/conf.d/newrelic.ini
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
+# Add Amazon RDS TLS public certificate.
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem  /etc/ssl/certs/rds-combined-ca-bundle.pem
+
 # Composer
 # hadolint ignore=DL4006
 RUN curl -sS https://getcomposer.org/installer | php && \


### PR DESCRIPTION
#### What does this PR do?

Adds the RDS CA pem bundle to our app images. This will allow us to enable TLS on database connections with

```
skpr config-set prod mysql.tls.cert /etc/ssl/certs/rds-combined-ca-bundle.pem
```

If we ever have projects hosted on other cloud providers (gcloud/azure), the certs for that provider into the project-specific `Dockerfile` and the skpr config path updated accordingly.

#### Any background context you want to provide?

There will be related PRs in other repos coming ASAP.

#### What are the relevant tickets?

https://redmine.previousnext.com.au/issues/52191
