### PR TITLE
[#52379] Refactored chrome-headless build to use pinned deb packages.

### DIFF
--- a/chrome-headless/Dockerfile
+++ b/chrome-headless/Dockerfile
@@ -1,11 +1,11 @@
 FROM debian:sid
+ARG CHROME_VERSION=68
+VOLUME /tmp
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl gnupg && \
-    curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends google-chrome-stable && \
+    apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl && \
+    curl -Ls -o /tmp/google-chrome.deb https://s3-ap-southeast-2.amazonaws.com/pnx-misc/apt-archive/google-chrome-stable/${CHROME_VERSION}-amd64-linux.deb && \
+    apt install -y /tmp/google-chrome.deb && \
     apt-get purge --auto-remove -y curl gnupg && \
     rm -rf /var/lib/apt/lists/*
 

--- a/chrome-headless/Makefile
+++ b/chrome-headless/Makefile
@@ -5,7 +5,9 @@ VERSION=latest
 
 # Build and tests
 build:
-	docker build -t $(IMAGE):$(VERSION) .
+	docker build --build-arg CHROME_VERSION=68 -t $(IMAGE):68 -t $(IMAGE):$(VERSION) .
+	docker build --build-arg CHROME_VERSION=67 -t $(IMAGE):67 .
+	docker build --build-arg CHROME_VERSION=65 -t $(IMAGE):65 .
 
 lint:
 	hadolint Dockerfile
@@ -13,5 +15,8 @@ lint:
 # Build and release
 release: build
 	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE):68
+	docker push $(IMAGE):67
+	docker push $(IMAGE):65
 
 .PHONY: build lint release


### PR DESCRIPTION
#### What does this PR do?

Additional builds for pinning to specific chrome versions.

#### How should this be manually tested?

Update your docker-compose stack to use a specific version

```
previousnext/chrome-headless:65
previousnext/chrome-headless:67
previousnext/chrome-headless:68
```

#### Any background context you want to provide?

Bump to google chrome 68 caused this issue https://gitlab.com/weitzman/drupal-test-traits/-/jobs/87528339

Google delete the old package files from google-chrome-stable, so I had to use wayback machine to find the old versions. This means I was unable to get chrome 66.

#### What are the relevant tickets?

https://redmine.previousnext.com.au/issues/52379
