### PR TITLE
Refactored frontend image to use official node:8-alpine for base image.

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
-ARG ALPINE_VERSION=3.8
+ARG NODE_VERSION=8
 
-FROM alpine:${ALPINE_VERSION}
+FROM node:${NODE_VERSION}-alpine
 
 ENV PATH "$PATH:/data/node_modules/.bin"
 
@@ -9,10 +9,4 @@ RUN apk add --no-cache -u \
     bash-completion \
     curl \
     make \
-    g++ \
-    jq \
-    libffi-dev \
-    nodejs \
-    npm \
-    python2 \
-    yarn
+    python2

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -24,6 +24,6 @@ build:
 
 # Build and release
 release: build
-	$(call build_test,8)
+	$(call push,8)
 
 .PHONY: build test lint release

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,16 +1,29 @@
 IMAGE=previousnext/frontend
-VERSION=latest
+PLATFORM=node
+TIMESTAMP=$(shell date +%F)
 
 # Build and tests
-build:
-	docker build -t $(IMAGE):$(VERSION) .
-	container-structure-test test --image $(IMAGE):$(VERSION) --config tests/frontend.yml
+define build_test
+	docker build \
+		--build-arg NODE_VERSION=$(1) \
+		-t $(IMAGE):$(PLATFORM)-$(1) \
+		-t $(IMAGE):$(PLATFORM)-$(1)-$(TIMESTAMP)	.
+	container-structure-test test --image $(IMAGE):$(PLATFORM)-$(1) --config tests/frontend.yml
+endef
+
+define push
+	docker push $(IMAGE):$(PLATFORM)-$(1)
+	docker push $(IMAGE):$(PLATFORM)-$(1)-$(TIMESTAMP)
+endef
 
 lint:
-	hadolint Dockerfile	
+	hadolint Dockerfile
+
+build:
+	$(call build_test,8)
 
 # Build and release
 release: build
-	docker push $(IMAGE):$(VERSION)
+	$(call build_test,8)
 
 .PHONY: build test lint release

--- a/frontend/tests/frontend.yml
+++ b/frontend/tests/frontend.yml
@@ -4,12 +4,12 @@ commandTests:
   - name: 'command exists: npm'
     command: "npm"
     args: ["-v"]
-    expectedOutput: ["5.6"]
+    expectedOutput: ["6"]
 
   - name: 'command exists: yarn'
     command: "yarn"
     args: ["-v"]
-    expectedOutput: ["1.7"]
+    expectedOutput: ["1.9"]
 
   - name: 'check node version'
     command: 'node'


### PR DESCRIPTION
* Changed the base image to `node:$NODE_VERSION-alpine`
* Refactored make file for easier support for multiple node version
* Changed the image tag to include a "platform" - so we could potentially make a legacy image for `ruby`, or whatever hotness the frontenders want to experiment with in future.