### PR TITLE
Adds fileinfo php package

### DIFF
--- a/php/apache/Dockerfile
+++ b/php/apache/Dockerfile
@@ -28,6 +28,7 @@ RUN apk --update --no-cache add \
             php${PHP_VERSION}-ctype \
             php${PHP_VERSION}-curl \
             php${PHP_VERSION}-dom \
+            php${PHP_VERSION}-fileinfo \
             php${PHP_VERSION}-ftp \
             php${PHP_VERSION}-gd \
             php${PHP_VERSION}-iconv \


### PR DESCRIPTION
Fixes an issue with Drupal composer dependency phar-stream-wrapperi now requiring ext-fileinfo














(i.e. Go / Terraform / Docker)