### PR TITLE
Switch to alpine 3.9 and node 10 (stable)

### DIFF
--- a/php/apache/Makefile
+++ b/php/apache/Makefile
@@ -49,11 +49,11 @@ build: 7.1 7.2 7.3
 
 # Build PHP 7.1
 7.1:
-	$(call build_test,7.1,3.8)
+	$(call build_test,7.1,3.9)
 
 # Build PHP 7.2
 7.2:
-	$(call build_test,7.2,3.8)
+	$(call build_test,7.2,3.9)
 
 # Build PHP 7.3
 7.3:

--- a/php/apache/dev/Dockerfile
+++ b/php/apache/dev/Dockerfile
@@ -13,8 +13,8 @@ RUN apk add -u g++ \
                git \
                libffi-dev \
                jq \
-               nodejs-current \
-               nodejs-current-npm \
+               nodejs \
+               npm \
                patch \
                php${PHP_VERSION}-xdebug \
                python \

--- a/php/apache/dev/tests/alpine3.9.yml
+++ b/php/apache/dev/tests/alpine3.9.yml
@@ -4,4 +4,4 @@ commandTests:
   - name: 'check node version'
     command: 'node'
     args: ['-v']
-    expectedOutput: ['v11.3.0']
+    expectedOutput: ['v10']


### PR DESCRIPTION
Currently we are using an unstable version of node (v9) in the dev containers. At least one package we're using requires a stable version of node (v10).

This PR switches to node v10 by:
- Switching to alpine 3.9
- using nodejs and npm packages, instead of nodejs-current and nodejs-current-npm