### PR TITLE
Adds an apache2 alpine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
     <<: *build
     environment:
       - DIR: apache2
-  apache2:
+  apache2-alpine:
     <<: *build
     environment:
       - DIR: apache2/alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,14 @@ build: &build
           fi
 
 jobs:
-  apache2:
+  apache2-legacy:
     <<: *build
     environment:
       - DIR: apache2
+  apache2:
+    <<: *build
+    environment:
+      - DIR: apache2/alpine
   athenapdf:
     <<: *build
     environment:
@@ -95,7 +99,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - apache2
+      - apache2-legacy
+      - apache2-alpine
       - athenapdf
       - cf-log-analyzer
       - chrome_headless
@@ -114,7 +119,8 @@ workflows:
       - solr
   weekly:
     jobs:
-      - apache2
+      - apache2-legacy
+      - apache2-alpine
       - athenapdf
       - cf-log-analyzer
       - chrome_headless

--- a/apache2/alpine/.bashrc
+++ b/apache2/alpine/.bashrc
@@ -1,0 +1,2 @@
+export PS1='\u@\h:\W \$ '
+source /etc/profile.d/bash_completion.sh

--- a/apache2/alpine/Dockerfile
+++ b/apache2/alpine/Dockerfile
@@ -15,13 +15,12 @@ RUN apk add --update --no-cache \
   vim
 
 # Tuner - https://github.com/previousnext/tuner
-RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-linux-amd64 -o /usr/local/bin/tuner && \
+RUN curl -sL https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-linux-amd64 -o /usr/local/bin/tuner && \
     chmod +rx /usr/local/bin/tuner
 
 # Logging
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
-
 
 COPY .bashrc /root/.bashrc
 COPY httpd.conf /etc/apache2/httpd.conf
@@ -37,4 +36,14 @@ VOLUME /var/run/tuner/apache2
 
 WORKDIR /data
 
-CMD ["httpd -D FOREGROUND"]
+# https://www.camptocamp.com/en/actualite/flexible-docker-entrypoints-scripts/
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY /docker-entrypoint.d/* /docker-entrypoint.d/
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+# @todo, Change to use "httpd -D FOREGROUND" once entrypoint.sh can be retired.
+CMD ["/entrypoint.sh"]

--- a/apache2/alpine/Dockerfile
+++ b/apache2/alpine/Dockerfile
@@ -1,0 +1,39 @@
+ARG ALPINE_VERSION=3.9
+
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add --update --no-cache \
+  apache2 \
+  apache2-utils \
+  bash \
+  bash-completion \
+  curl \
+  make \
+  rsync \
+  unzip \
+  vim
+
+# Tuner - https://github.com/previousnext/tuner
+RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-linux-amd64 -o /usr/local/bin/tuner && \
+    chmod +rx /usr/local/bin/tuner
+
+# Logging
+RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
+    ln -sf /dev/stderr /var/log/apache2/error.log
+
+
+COPY .bashrc /root/.bashrc
+COPY httpd.conf /etc/apache2/httpd.conf
+COPY status.conf /etc/apache2/conf.d/status.conf
+COPY security.conf /etc/apache2/conf.d/security.conf
+
+# These volumes allow us to run our containers in "readonly" mode.
+VOLUME /run/apache2
+VOLUME /run/lock/apache2
+VOLUME /tmp
+VOLUME /var/log/newrelic
+VOLUME /var/run/tuner/apache2
+
+WORKDIR /data
+
+CMD ["httpd -D FOREGROUND"]

--- a/apache2/alpine/Dockerfile
+++ b/apache2/alpine/Dockerfile
@@ -2,6 +2,7 @@ ARG ALPINE_VERSION=3.9
 
 FROM alpine:${ALPINE_VERSION}
 
+# hadolint ignore=DL3018
 RUN apk add --update --no-cache \
   apache2 \
   apache2-utils \

--- a/apache2/alpine/Makefile
+++ b/apache2/alpine/Makefile
@@ -1,0 +1,42 @@
+#!/usr/bin/make -f
+
+IMAGE=previousnext/apache2-alpine
+VERSION=1.x
+ALPINE_VERSION=3.9
+
+# Allows for providing unique tags for images based on when they were built.
+# Ideal for debugging!
+TIMESTAMP=$(shell date +%F)
+
+define push
+
+endef
+
+# Build all PHP versions
+build:
+	# Building and testing PROD...
+	docker build --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
+               -t ${IMAGE}:${VERSION} \
+               -t ${IMAGE}:${TIMESTAMP} \
+               --no-cache .
+	# Building and testing DEV...
+	docker build -f dev/Dockerfile \
+	             --build-arg FROM=${IMAGE}:${VERSION} \
+	             --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
+               -t ${IMAGE}:${VERSION}-dev \
+               -t ${IMAGE}:${TIMESTAMP}-dev \
+               --no-cache dev
+
+lint:
+	hadolint Dockerfile
+
+# Build and release
+release: build
+	# Pushing PROD...
+	docker push ${IMAGE}:${VERSION}
+	docker push ${IMAGE}:${TIMESTAMP}
+	# Pushing DEV...
+	docker push ${IMAGE}:${VERSION}-dev
+	docker push ${IMAGE}:${TIMESTAMP}-dev
+
+.PHONY: build lint release

--- a/apache2/alpine/Makefile
+++ b/apache2/alpine/Makefile
@@ -29,6 +29,8 @@ build:
 
 lint:
 	hadolint Dockerfile
+	hadolint dev/Dockerfile
+	
 
 # Build and release
 release: build

--- a/apache2/alpine/dev/Dockerfile
+++ b/apache2/alpine/dev/Dockerfile
@@ -9,26 +9,26 @@ RUN apk add --update --no-cache \
    yarn
 
 # Skipper
-RUN curl -LO http://bins.skpr.io/linux-amd64-latest.tar.gz && \
+RUN curl -sLO http://bins.skpr.io/linux-amd64-latest.tar.gz && \
     tar -zxf linux-amd64-latest.tar.gz -C /usr/local/bin/ && \
     rm -rf linux-amd64-latest.tar.gz
 
 # M8s
-RUN curl -L https://github.com/previousnext/m8s/releases/download/v0.8.0/m8s_linux_amd64 -o /usr/local/bin/m8s && \
+RUN curl -sL https://github.com/previousnext/m8s/releases/download/v0.8.0/m8s_linux_amd64 -o /usr/local/bin/m8s && \
     chmod a+x /usr/local/bin/m8s
 
 # Github deploy status
-RUN curl -L https://github.com/previousnext/go-deploy-status/releases/download/1.0.0-alpha3/deploy-status_linux_amd64 -o /usr/local/bin/deploy-status && \
+RUN curl -sL https://github.com/previousnext/go-deploy-status/releases/download/1.0.0-alpha3/deploy-status_linux_amd64 -o /usr/local/bin/deploy-status && \
     chmod a+x /usr/local/bin/deploy-status
 
 # Hub
-RUN curl -L http://bins.skpr.io/hub-latest -o /usr/local/bin/hub && \
+RUN curl -sL http://bins.skpr.io/hub-latest -o /usr/local/bin/hub && \
       chmod +rx /usr/local/bin/hub
 
 # Notify - https://github.com/previousnext/notify
-RUN curl -L https://github.com/previousnext/notify/releases/download/2.1.0/notify_linux_amd64 -o /usr/local/bin/notify && \
+RUN curl -sL https://github.com/previousnext/notify/releases/download/2.1.0/notify_linux_amd64 -o /usr/local/bin/notify && \
     chmod +rx /usr/local/bin/notify
 
 # Semantic - https://github.com/nickschuch/semantic
-RUN curl -L https://github.com/nickschuch/semantic/releases/download/0.0.2/semantic-linux-amd64 -o /usr/local/bin/semantic && \
+RUN curl -sL https://github.com/nickschuch/semantic/releases/download/0.0.2/semantic-linux-amd64 -o /usr/local/bin/semantic && \
     chmod +rx /usr/local/bin/semantic

--- a/apache2/alpine/dev/Dockerfile
+++ b/apache2/alpine/dev/Dockerfile
@@ -1,0 +1,35 @@
+FROM previousnext/apache2-alpine:1.x
+
+RUN apk add --update --no-cache \
+   git \
+   nodejs \
+   npm \
+   patch \
+   openssh-client \
+   wget \
+   yarn
+
+# Skipper
+RUN wget http://bins.skpr.io/linux-amd64-latest.tar.gz && \
+    tar -zxf linux-amd64-latest.tar.gz -C /usr/local/bin/ && \
+    rm -rf linux-amd64-latest.tar.gz
+
+# M8s
+RUN curl -L https://github.com/previousnext/m8s/releases/download/v0.8.0/m8s_linux_amd64 -o /usr/local/bin/m8s && \
+    chmod a+x /usr/local/bin/m8s
+
+# Github deploy status
+RUN curl -L https://github.com/previousnext/go-deploy-status/releases/download/1.0.0-alpha3/deploy-status_linux_amd64 -o /usr/local/bin/deploy-status && \
+    chmod a+x /usr/local/bin/deploy-status
+
+# Hub
+RUN curl -L http://bins.skpr.io/hub-latest -o /usr/local/bin/hub && \
+      chmod +rx /usr/local/bin/hub
+
+# Notify - https://github.com/previousnext/notify
+RUN curl -L https://github.com/previousnext/notify/releases/download/2.1.0/notify_linux_amd64 -o /usr/local/bin/notify && \
+    chmod +rx /usr/local/bin/notify
+
+# Semantic - https://github.com/nickschuch/semantic
+RUN curl -L https://github.com/nickschuch/semantic/releases/download/0.0.2/semantic-linux-amd64 -o /usr/local/bin/semantic && \
+    chmod +rx /usr/local/bin/semantic

--- a/apache2/alpine/dev/Dockerfile
+++ b/apache2/alpine/dev/Dockerfile
@@ -1,16 +1,15 @@
 FROM previousnext/apache2-alpine:1.x
 
+# hadolint ignore=DL3018
 RUN apk add --update --no-cache \
    git \
    nodejs \
    npm \
-   patch \
    openssh-client \
-   wget \
    yarn
 
 # Skipper
-RUN wget http://bins.skpr.io/linux-amd64-latest.tar.gz && \
+RUN curl -LO http://bins.skpr.io/linux-amd64-latest.tar.gz && \
     tar -zxf linux-amd64-latest.tar.gz -C /usr/local/bin/ && \
     rm -rf linux-amd64-latest.tar.gz
 

--- a/apache2/alpine/docker-entrypoint.d/tuner.sh
+++ b/apache2/alpine/docker-entrypoint.d/tuner.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Name:    tuner.sh
+# Author:  Nick Schuch
+# Comment: Configure Apache + PHP based on resources.
+
+echo "Tuning: Apache: /var/run/tuner/apache2/tuner.conf"
+tuner --conf=apache > /var/run/tuner/apache2/tuner.conf

--- a/apache2/alpine/docker-entrypoint.sh
+++ b/apache2/alpine/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]]; then
+  for f in $DIR/*.sh; do
+    echo "Running entrypoint.d script: $f"
+    bash "$f" -H   || break
+  done
+fi
+
+exec "$@"

--- a/apache2/alpine/entrypoint.sh
+++ b/apache2/alpine/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Name:    start.sh
+# Author:  Nick Schuch
+# Comment: A lightweight script for configuring and starting Apache
+
+httpd -D FOREGROUND

--- a/apache2/alpine/httpd.conf
+++ b/apache2/alpine/httpd.conf
@@ -1,0 +1,473 @@
+#
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/access_log"
+# with ServerRoot set to "/usr/local/apache2" will be interpreted by the
+# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log" 
+# will be interpreted as '/logs/access_log'.
+
+#
+# ServerTokens
+# This directive configures what you return as the Server HTTP response
+# Header. The default is 'Full' which sends information about the OS-Type
+# and compiled in modules.
+# Set to one of:  Full | OS | Minor | Minimal | Major | Prod
+# where Full conveys the most information, and Prod the least.
+#
+ServerTokens OS
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# Do not add a slash at the end of the directory path.  If you point
+# ServerRoot at a non-local disk, be sure to specify a local disk on the
+# Mutex directive, if file-based mutexes are used.  If you wish to share the
+# same ServerRoot for multiple httpd daemons, you will need to change at
+# least PidFile.
+#
+ServerRoot /var/www
+
+#
+# Mutex: Allows you to set the mutex mechanism and mutex file directory
+# for individual mutexes, or change the global defaults
+#
+# Uncomment and change the directory if mutexes are file-based and the default
+# mutex file directory is not on a local disk or is not appropriate for some
+# other reason.
+#
+# Mutex default:/run/apache2
+
+#
+# Listen: Allows you to bind Apache to specific IP addresses and/or
+# ports, instead of the default. See also the <VirtualHost>
+# directive.
+#
+# Change this to Listen on specific IP addresses as shown below to 
+# prevent Apache from glomming onto all bound IP addresses.
+#
+#Listen 12.34.56.78:80
+Listen 80
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+#LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+#LoadModule mpm_worker_module modules/mod_mpm_worker.so
+LoadModule authn_file_module modules/mod_authn_file.so
+#LoadModule authn_dbm_module modules/mod_authn_dbm.so
+#LoadModule authn_anon_module modules/mod_authn_anon.so
+#LoadModule authn_dbd_module modules/mod_authn_dbd.so
+#LoadModule authn_socache_module modules/mod_authn_socache.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+#LoadModule authz_dbm_module modules/mod_authz_dbm.so
+#LoadModule authz_owner_module modules/mod_authz_owner.so
+#LoadModule authz_dbd_module modules/mod_authz_dbd.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+#LoadModule auth_form_module modules/mod_auth_form.so
+#LoadModule auth_digest_module modules/mod_auth_digest.so
+#LoadModule allowmethods_module modules/mod_allowmethods.so
+#LoadModule file_cache_module modules/mod_file_cache.so
+#LoadModule cache_module modules/mod_cache.so
+#LoadModule cache_disk_module modules/mod_cache_disk.so
+#LoadModule cache_socache_module modules/mod_cache_socache.so
+#LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+#LoadModule socache_dbm_module modules/mod_socache_dbm.so
+#LoadModule socache_memcache_module modules/mod_socache_memcache.so
+#LoadModule watchdog_module modules/mod_watchdog.so
+#LoadModule macro_module modules/mod_macro.so
+#LoadModule dbd_module modules/mod_dbd.so
+#LoadModule dumpio_module modules/mod_dumpio.so
+#LoadModule echo_module modules/mod_echo.so
+#LoadModule buffer_module modules/mod_buffer.so
+#LoadModule data_module modules/mod_data.so
+#LoadModule ratelimit_module modules/mod_ratelimit.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+#LoadModule ext_filter_module modules/mod_ext_filter.so
+#LoadModule request_module modules/mod_request.so
+#LoadModule include_module modules/mod_include.so
+LoadModule filter_module modules/mod_filter.so
+#LoadModule reflector_module modules/mod_reflector.so
+#LoadModule substitute_module modules/mod_substitute.so
+#LoadModule sed_module modules/mod_sed.so
+#LoadModule charset_lite_module modules/mod_charset_lite.so
+LoadModule deflate_module modules/mod_deflate.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule log_config_module modules/mod_log_config.so
+#LoadModule log_debug_module modules/mod_log_debug.so
+#LoadModule log_forensic_module modules/mod_log_forensic.so
+#LoadModule logio_module modules/mod_logio.so
+LoadModule env_module modules/mod_env.so
+#LoadModule mime_magic_module modules/mod_mime_magic.so
+#LoadModule expires_module modules/mod_expires.so
+LoadModule headers_module modules/mod_headers.so
+#LoadModule usertrack_module modules/mod_usertrack.so
+#LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+#LoadModule remoteip_module modules/mod_remoteip.so
+#LoadModule session_module modules/mod_session.so
+#LoadModule session_cookie_module modules/mod_session_cookie.so
+#LoadModule session_crypto_module modules/mod_session_crypto.so
+#LoadModule session_dbd_module modules/mod_session_dbd.so
+#LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+#LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+#LoadModule dialup_module modules/mod_dialup.so
+#LoadModule http2_module modules/mod_http2.so
+LoadModule unixd_module modules/mod_unixd.so
+#LoadModule heartbeat_module modules/mod_heartbeat.so
+#LoadModule heartmonitor_module modules/mod_heartmonitor.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+#LoadModule asis_module modules/mod_asis.so
+#LoadModule info_module modules/mod_info.so
+#LoadModule suexec_module modules/mod_suexec.so
+<IfModule !mpm_prefork_module>
+	#LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+	#LoadModule cgi_module modules/mod_cgi.so
+</IfModule>
+LoadModule vhost_alias_module modules/mod_vhost_alias.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+#LoadModule actions_module modules/mod_actions.so
+#LoadModule speling_module modules/mod_speling.so
+#LoadModule userdir_module modules/mod_userdir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+LoadModule negotiation_module modules/mod_negotiation.so
+
+<IfModule unixd_module>
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+# It is usually good practice to create a dedicated user and group for
+# running httpd, as with most system services.
+#
+User apache
+Group apache
+
+</IfModule>
+
+# 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+ServerAdmin you@example.com
+
+#
+# Optionally add a line containing the server version and virtual host
+# name to server-generated pages (internal error documents, FTP directory
+# listings, mod_status and mod_info output etc., but not CGI generated
+# documents or custom error documents).
+# Set to "EMail" to also include a mailto: link to the ServerAdmin.
+# Set to one of:  On | Off | EMail
+#
+ServerSignature On
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+#
+#ServerName www.example.com:80
+
+#
+# Deny access to the entirety of your server's filesystem. You must
+# explicitly permit access to web content directories in other 
+# <Directory> blocks below.
+#
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/data/app"
+<Directory "/data/app">
+    Options Indexes FollowSymLinks
+    AllowOverride All
+    Require all granted
+</Directory>
+
+# A set of health checking scripts for this project.
+# Users can add more to this directory via the Dockerfile.
+# Details for how to use these scripts can be found here:
+#   https://docs.skpr.io/developer/drupal
+Alias "/liveness" "/var/www/liveness"
+
+# All health checks are blocked from external access.
+# Anything proxied from a layer 7 balancer will not be
+# allowed to check the health of the application.
+SetEnvIF X-Forwarded-For ^$ Internal
+<Directory /var/www/liveness>
+  Require env Internal
+</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ".ht*">
+    Require all denied
+</Files>
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog logs/error.log
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    #CustomLog logs/access.log common
+
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    CustomLog logs/access.log combined
+</IfModule>
+
+<IfModule alias_module>
+    #
+    # Redirect: Allows you to tell clients about documents that used to 
+    # exist in your server's namespace, but do not anymore. The client 
+    # will make a new request for the document at its new location.
+    # Example:
+    # Redirect permanent /foo http://www.example.com/bar
+
+    #
+    # Alias: Maps web paths into filesystem paths and is used to
+    # access content that does not live under the DocumentRoot.
+    # Example:
+    # Alias /webpath /full/filesystem/path
+    #
+    # If you include a trailing / on /webpath then the server will
+    # require it to be present in the URL.  You will also likely
+    # need to provide a <Directory> section to allow access to
+    # the filesystem path.
+
+    #
+    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAliases are essentially the same as Aliases, except that
+    # documents in the target directory are treated as applications and
+    # run by the server when requested rather than as documents sent to the
+    # client.  The same rules about trailing "/" apply to ScriptAlias
+    # directives as to Alias.
+    #
+    ScriptAlias /cgi-bin/ "/var/www/localhost/cgi-bin/"
+
+</IfModule>
+
+<IfModule cgid_module>
+    #
+    # ScriptSock: On threaded servers, designate the path to the UNIX
+    # socket used to communicate with the CGI daemon of mod_cgid.
+    #
+    #Scriptsock cgisock
+</IfModule>
+
+#
+# "/var/www/localhost/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+<Directory "/var/www/localhost/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    #
+    # Avoid passing HTTP_PROXY environment to CGI's on this or any proxied
+    # backend servers which have lingering "httpoxy" defects.
+    # 'Proxy' request header is undefined by the IETF, not listed by IANA
+    #
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    #
+    # TypesConfig points to the file containing the list of mappings from
+    # filename extension to MIME-type.
+    #
+    TypesConfig /etc/apache2/mime.types
+
+    #
+    # AddType allows you to add to or override the MIME configuration
+    # file specified in TypesConfig for specific file types.
+    #
+    #AddType application/x-gzip .tgz
+    #
+    # AddEncoding allows you to have certain browsers uncompress
+    # information on the fly. Note: Not all browsers support this.
+    #
+    #AddEncoding x-compress .Z
+    #AddEncoding x-gzip .gz .tgz
+    #
+    # If the AddEncoding directives above are commented-out, then you
+    # probably should define those extensions to indicate media types:
+    #
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+
+    #
+    # AddHandler allows you to map certain file extensions to "handlers":
+    # actions unrelated to filetype. These can be either built into the server
+    # or added with the Action directive (see below)
+    #
+    # To use CGI scripts outside of ScriptAliased directories:
+    # (You will also need to add "ExecCGI" to the "Options" directive.)
+    #
+    #AddHandler cgi-script .cgi
+
+    # For type maps (negotiated resources):
+    #AddHandler type-map var
+
+    #
+    # Filters allow you to process content before it is sent to the client.
+    #
+    # To parse .shtml files for server-side includes (SSI):
+    # (You will also need to add "Includes" to the "Options" directive.)
+    #
+    #AddType text/html .shtml
+    #AddOutputFilter INCLUDES .shtml
+</IfModule>
+
+#
+# The mod_mime_magic module allows the server to use various hints from the
+# contents of the file itself to determine its type.  The MIMEMagicFile
+# directive tells the module where the hint definitions are located.
+#
+<IfModule mime_magic_module>
+    MIMEMagicFile /etc/apache2/magic
+</IfModule>
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# MaxRanges: Maximum number of Ranges in a request before
+# returning the entire resource, or one of the special
+# values 'default', 'none' or 'unlimited'.
+# Default setting is to accept 200 Ranges.
+#MaxRanges unlimited
+
+#
+# EnableMMAP and EnableSendfile: On systems that support it, 
+# memory-mapping or the sendfile syscall may be used to deliver
+# files.  This usually improves server performance, but must
+# be turned off when serving from networked-mounted 
+# filesystems or if support for these functions is otherwise
+# broken on your system.
+# Defaults: EnableMMAP On, EnableSendfile Off
+#
+#EnableMMAP off
+#EnableSendfile on
+
+# Load config files from the config directory "/etc/apache2/conf.d".
+#
+IncludeOptional /etc/apache2/conf.d/*.conf
+IncludeOptional /var/run/tuner/apache2/*.conf

--- a/apache2/alpine/security.conf
+++ b/apache2/alpine/security.conf
@@ -1,0 +1,3 @@
+ServerTokens ProductOnly
+ServerSignature Off
+TraceEnable Off

--- a/apache2/alpine/status.conf
+++ b/apache2/alpine/status.conf
@@ -1,0 +1,16 @@
+<IfModule mod_status.c>
+
+<Location /server-status>
+     SetHandler server-status
+
+     Order deny,allow
+     Deny from all
+     Allow from localhost ip6-localhost 127.0.0.1
+     Satisfy any
+
+     <IfModule mod_rewrite.c>
+          RewriteEngine off
+     </IfModule>
+</Location>
+
+</IfModule>


### PR DESCRIPTION
Front-end developers just need an apache instance to serve static files (e.g. for a generated styleguide). 

This adds an apache image with skpr tooling, as well as a dev image which includes front-end dev tools such as node, npm and yarn.