### PR TITLE
Move docconv to prod image

### DIFF
--- a/php/apache/Dockerfile
+++ b/php/apache/Dockerfile
@@ -103,6 +103,9 @@ RUN curl -sS https://getcomposer.org/installer | php && \
 RUN curl -L https://github.com/previousnext/tuner/releases/download/1.0.0/tuner-linux-amd64 -o /usr/local/bin/tuner && \
     chmod +rx /usr/local/bin/tuner
 
+RUN curl -L https://s3.amazonaws.com/pnx-bins/docconv-v1.0.0-129-geedabc4-alpine3.9 -o /usr/local/bin/docconv && \
+    chmod +rx /usr/local/bin/docconv
+
 # Ruby errors if a sticky bit isn't set on /tmp.
 # @expire 2019-06-30
 RUN chmod +t /tmp

--- a/php/apache/dev/Dockerfile
+++ b/php/apache/dev/Dockerfile
@@ -73,7 +73,4 @@ RUN curl -L https://github.com/previousnext/microcron/releases/download/v0.0.1/m
 RUN curl -L https://github.com/nickschuch/semantic/releases/download/0.0.2/semantic-linux-amd64 -o /usr/local/bin/semantic && \
     chmod +rx /usr/local/bin/semantic
 
-RUN curl -L https://s3.amazonaws.com/pnx-bins/docconv-v1.0.0-129-geedabc4-alpine3.9 -o /usr/local/bin/docconv && \
-    chmod +rx /usr/local/bin/docconv
-
 COPY /docker-entrypoint.d/* /docker-entrypoint.d/


### PR DESCRIPTION
#### What does this PR do?

Moves the docconv bin from the dev image to the prod image.