### PR TITLE
Set xdebug.coverage_enable=0 xdebug.default_enable=0

### DIFF
--- a/php/apache/dev/xdebug.ini
+++ b/php/apache/dev/xdebug.ini
@@ -1,4 +1,6 @@
 zend_extension=xdebug.so
+xdebug.coverage_enable=0
+xdebug.default_enable=0
 xdebug.max_nesting_level=256 ; Fixes debugging for D8.
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp


### PR DESCRIPTION
* Xdebug is turned on by default
* Every web request is generating a converage report