### PR TITLE
Enabled distributed tracing configs.

### DIFF
--- a/php/apache/newrelic.ini
+++ b/php/apache/newrelic.ini
@@ -856,3 +856,8 @@ newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
 ;          agent will not connect. 
 ;
 ;newrelic.security_policies_token = ""
+;
+; Distributed Tracing
+newrelic.transaction_tracer.enabled = true
+newrelic.distributed_tracing_enabled = true
+newrelic.transaction_tracer.threshold = 0


### PR DESCRIPTION
Adding this for compatibility with SNSW standardised new relic policy.

https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php-agent