### PR TITLE
Set 'expose_php = off'

### DIFF
--- a/php/apache/Dockerfile
+++ b/php/apache/Dockerfile
@@ -75,6 +75,7 @@ COPY security.conf /etc/apache2/conf.d/security.conf
 COPY drushrc.php /etc/drush/drushrc.php
 COPY drush.yml /etc/drush/drush.yml
 COPY apcu.ini /etc/php7/conf.d/01_apcu.ini
+COPY overrides.ini /etc/php7/conf.d/50_overrides.ini
 COPY skpr.php /etc/skpr/skpr.php
 
 # Liveness

--- a/php/apache/overrides.ini
+++ b/php/apache/overrides.ini
@@ -1,0 +1,2 @@
+# This is to avoid X-Powered-By header being returned to the browser.
+expose_php = off


### PR DESCRIPTION
Don't show PHP version in headers.