### PR TITLE
Update clamav Dockerfile to use https

### DIFF
--- a/clamd/Dockerfile
+++ b/clamd/Dockerfile
@@ -5,9 +5,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apk add --no-cache -u clamav-daemon python py-pip wget clamav-libunrar unrar
 
-RUN wget -nv -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
-    wget -nv -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
-    wget -nv -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
+RUN wget -nv -O /var/lib/clamav/main.cvd https://database.clamav.net/main.cvd && \
+    wget -nv -O /var/lib/clamav/daily.cvd https://database.clamav.net/daily.cvd && \
+    wget -nv -O /var/lib/clamav/bytecode.cvd https://database.clamav.net/bytecode.cvd && \
     chown clamav:clamav /var/lib/clamav/*.cvd && \
     mkdir /run/clamav && \
     chown clamav:clamav /run/clamav


### PR DESCRIPTION
Clamav databases are using http URLs.